### PR TITLE
IPI-faltando-icms70-e-reorganizado-metodos

### DIFF
--- a/src/Delphiscal.Cofins01_02.pas
+++ b/src/Delphiscal.Cofins01_02.pas
@@ -12,10 +12,10 @@ type
     function BaseCofins: Double;
     function ValorCofins: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-      AAliquotaCofins: Double);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
       AAliquotaCofins: Double): ICofins01_02;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
+      AAliquotaCofins: Double);
     destructor Destroy; override;
   end;
 
@@ -23,9 +23,10 @@ implementation
 
 uses Delphiscal.Utils;
 
-function TCofins01_02.BaseCofins: Double;
+class function TCofins01_02.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
+  AAliquotaCofins: Double): ICofins01_02;
 begin
-  Result := FBaseCofins.CalcularBaseCofins;
+  Result := TCofins01_02.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaCofins);
 end;
 
 constructor TCofins01_02.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
@@ -41,10 +42,9 @@ begin
   inherited;
 end;
 
-class function TCofins01_02.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-  AAliquotaCofins: Double): ICofins01_02;
+function TCofins01_02.BaseCofins: Double;
 begin
-  Result := TCofins01_02.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaCofins);
+  Result := FBaseCofins.CalcularBaseCofins;
 end;
 
 function TCofins01_02.ValorCofins: Double;

--- a/src/Delphiscal.Cofins03.pas
+++ b/src/Delphiscal.Cofins03.pas
@@ -13,19 +13,18 @@ type
     function QuantidadeTributada(const AValue: Double): ICofins03;
     function ValorPorUnidadeTributada(const AValue: Double): ICofins03;
   public
-    constructor Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double); overload;
-    class function New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): ICofins03; overload;
     class function New: ICofins03; overload;
+    class function New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): ICofins03; overload;
+    constructor Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double); overload;
   end;
 
 implementation
 
 uses Delphiscal.Utils;
 
-constructor TCofins03.Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double);
+class function TCofins03.New: ICofins03;
 begin
-  FQuantidadeTributada := AQuantidadeTributada;
-  FValorUnidadeTributada := AValorPorUnidadeTributada;
+  Result := TCofins03.Create;
 end;
 
 class function TCofins03.New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): ICofins03;
@@ -33,9 +32,10 @@ begin
   Result := TCofins03.Create(AQuantidadeTributada, AValorPorUnidadeTributada);
 end;
 
-class function TCofins03.New: ICofins03;
+constructor TCofins03.Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double);
 begin
-  Result := TCofins03.Create;
+  FQuantidadeTributada := AQuantidadeTributada;
+  FValorUnidadeTributada := AValorPorUnidadeTributada;
 end;
 
 function TCofins03.ValorCofins: Double;

--- a/src/Delphiscal.Icms.BaseST.pas
+++ b/src/Delphiscal.Icms.BaseST.pas
@@ -35,7 +35,7 @@ end;
 
 function TBaseIcmsST.CalcularBaseIcmsST: Double;
 begin
-  if FPercentualReducaoST > 0 then
+  if ContemReducaoST then
     Result := CalcularBaseReduzidaST
   else
     Result := CalcularBaseNormalST;

--- a/src/Delphiscal.Icms00.pas
+++ b/src/Delphiscal.Icms00.pas
@@ -12,10 +12,10 @@ type
     function BaseIcmsProprio: Double;
     function ValorIcmsProprio: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS: Double;
-      const AValorIpi: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS: Double;
-      const AValorIpi: Double = 0): IIcms00;
+                       const AValorIpi: Double = 0): IIcms00;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS: Double;
+                       const AValorIpi: Double = 0);
     destructor Destroy; override;
   end;
 
@@ -23,16 +23,18 @@ implementation
 
 uses Delphiscal.Utils;
 
-function TIcms00.BaseIcmsProprio: Double;
+class function TIcms00.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
+  AValorIpi: Double): IIcms00;
 begin
-  Result := RoundABNT(FBaseIcmsProprio.CalcularBaseIcmsProprio, 2);
+  Result := TIcms00.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
+                           AValorIpi);
 end;
 
 constructor TIcms00.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
   AALiquotaICMS: Double; const AValorIpi: Double = 0);
 begin
   FBaseIcmsProprio := TBaseIcmsProprio.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, 0,
-    AValorIpi);
+                                              AValorIpi);
   FValorIcms := TValorIcms.Create(FBaseIcmsProprio, AALiquotaICMS);
 end;
 
@@ -43,11 +45,9 @@ begin
   inherited;
 end;
 
-class function TIcms00.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
-  AValorIpi: Double): IIcms00;
+function TIcms00.BaseIcmsProprio: Double;
 begin
-  Result := TIcms00.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
-    AValorIpi);
+  Result := RoundABNT(FBaseIcmsProprio.CalcularBaseIcmsProprio, 2);
 end;
 
 function TIcms00.ValorIcmsProprio: Double;

--- a/src/Delphiscal.Icms10.pas
+++ b/src/Delphiscal.Icms10.pas
@@ -17,16 +17,23 @@ type
     function ValorIcmsST: Double;
     function ValorIcmsSTDesonerado: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-      AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
       AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0): IIcms10;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+      AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0);
     destructor Destroy; override;
   end;
 
 implementation
 
 uses Delphiscal.Utils;
+
+class function TIcms10.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+  AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi: Double): IIcms10;
+begin
+  Result := TIcms10.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+                           AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi);
+end;
 
 constructor TIcms10.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
   AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0);
@@ -44,13 +51,6 @@ begin
   FBaseIcmsST.Free;
   FIcmsST.Free;
   inherited;
-end;
-
-class function TIcms10.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-  AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi: Double): IIcms10;
-begin
-  Result := TIcms10.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-    AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi);
 end;
 
 function TIcms10.ValorBaseIcmsProprio: Double;

--- a/src/Delphiscal.Icms101.pas
+++ b/src/Delphiscal.Icms101.pas
@@ -12,10 +12,10 @@ type
     function BaseCreditoSN: Double;
     function ValorCreditoSN: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-      APercentualCreditoSN: Double; const APercentualReducao: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
       APercentualCreditoSN: Double; const APercentualReducao: Double = 0): IIcms101;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
+      APercentualCreditoSN: Double; const APercentualReducao: Double = 0);
     destructor Destroy; override;
   end;
 
@@ -23,16 +23,18 @@ implementation
 
 uses Delphiscal.Utils;
 
-function TIcms101.BaseCreditoSN: Double;
+class function TIcms101.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
+  APercentualCreditoSN, APercentualReducao: Double): IIcms101;
 begin
-  Result := RoundABNT(FBaseCreditoSN.CalcularBaseIcmsProprio, 2);
+  Result := TIcms101.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, APercentualCreditoSN,
+                            APercentualReducao);
 end;
 
 constructor TIcms101.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
   APercentualCreditoSN: Double; const APercentualReducao: Double = 0);
 begin
   FBaseCreditoSN := TBaseIcmsProprio.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-    APercentualReducao);
+                                            APercentualReducao);
   FPercentualCreditoSN := APercentualCreditoSN;
 end;
 
@@ -42,11 +44,9 @@ begin
   inherited;
 end;
 
-class function TIcms101.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-  APercentualCreditoSN, APercentualReducao: Double): IIcms101;
+function TIcms101.BaseCreditoSN: Double;
 begin
-  Result := TIcms101.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, APercentualCreditoSN,
-    APercentualReducao);
+  Result := RoundABNT(FBaseCreditoSN.CalcularBaseIcmsProprio, 2);
 end;
 
 function TIcms101.ValorCreditoSN: Double;

--- a/src/Delphiscal.Icms20.pas
+++ b/src/Delphiscal.Icms20.pas
@@ -13,10 +13,10 @@ type
     function ValorIcmsProprio: Double;
     function ValorIcmsDesonerado: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-      APercentualReducao: Double; const AValorIpi: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-      APercentualReducao: Double; const AValorIpi: Double = 0): IIcms20;
+                       APercentualReducao: Double; const AValorIpi: Double = 0): IIcms20;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+                       APercentualReducao: Double; const AValorIpi: Double = 0);
     destructor Destroy; override;
   end;
 
@@ -24,12 +24,26 @@ implementation
 
 uses Delphiscal.Utils;
 
+class function TIcms20.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+  APercentualReducao, AValorIpi: Double): IIcms20;
+begin
+  Result := TIcms20.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+                           APercentualReducao, AValorIpi);
+end;
+
 constructor TIcms20.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
   APercentualReducao: Double; const AValorIpi: Double = 0);
 begin
   FBaseReduzidaIcmsProprio := TBaseIcmsProprio.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias,
-    AValorDesconto, APercentualReducao, AValorIpi);
+                                                      AValorDesconto, APercentualReducao, AValorIpi);
   FValorIcms := TValorIcms.Create(FBaseReduzidaIcmsProprio, AAliquotaIcms);
+end;
+
+destructor TIcms20.Destroy;
+begin
+  FValorIcms.Free;
+  FBaseReduzidaIcmsProprio.Free;
+  inherited;
 end;
 
 function TIcms20.BaseReduzidaIcmsProprio: Double;
@@ -40,20 +54,6 @@ end;
 function TIcms20.ValorIcmsProprio: Double;
 begin
   Result := RoundABNT(FValorIcms.GetValorIcms, 2);
-end;
-
-destructor TIcms20.Destroy;
-begin
-  FValorIcms.Free;
-  FBaseReduzidaIcmsProprio.Free;
-  inherited;
-end;
-
-class function TIcms20.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-  APercentualReducao, AValorIpi: Double): IIcms20;
-begin
-  Result := TIcms20.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-    APercentualReducao, AValorIpi);
 end;
 
 function TIcms20.ValorIcmsDesonerado: Double;

--- a/src/Delphiscal.Icms201.pas
+++ b/src/Delphiscal.Icms201.pas
@@ -19,10 +19,10 @@ type
     function ValorIcmsST: Double;
     function ValorCreditoSN: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-      APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
       APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0): IIcms201;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+      APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0);
     destructor Destroy; override;
   end;
 
@@ -30,11 +30,18 @@ implementation
 
 uses Delphiscal.Utils;
 
+class function TIcms201.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+  APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva, APercentualReducaoST: Double): IIcms201;
+begin
+  Result := TIcms201.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+                            APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva, APercentualReducaoST);
+end;
+
 constructor TIcms201.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
   APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0);
 begin
   FBaseIcmsProprio := TBaseIcmsProprio.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-    APercentualReducao);
+                                              APercentualReducao);
   FIcmsProprio := TValorIcms.Create(FBaseIcmsProprio, AAliquotaIcms);
   FBaseIcmsST := TBaseIcmsST.Create(FBaseIcmsProprio, AMva, APercentualReducaoST);
   FIcmsST := TValorIcmsST.Create(FBaseIcmsST, AAliquotaIcmsST, FIcmsProprio);
@@ -50,26 +57,9 @@ begin
   inherited;
 end;
 
-class function TIcms201.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-  APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva, APercentualReducaoST: Double): IIcms201;
-begin
-  Result := TIcms201.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-    APercentualReducao, APercentualCreditoSN, AAliquotaIcmsST, AMva, APercentualReducaoST);
-end;
-
 function TIcms201.ValorBaseIcmsProprio: Double;
 begin
   Result := FBaseIcmsProprio.CalcularBaseIcmsProprio;
-end;
-
-function TIcms201.ValorBaseIcmsST: Double;
-begin
-  Result := FBaseIcmsST.CalcularBaseIcmsST;
-end;
-
-function TIcms201.ValorCreditoSN: Double;
-begin
-  Result := RoundABNT(ValorBaseIcmsProprio * (FPercentualCreditoSN / 100), 2);
 end;
 
 function TIcms201.ValorIcmsProprio: Double;
@@ -77,9 +67,19 @@ begin
   Result := RoundABNT(FIcmsProprio.GetValorIcms, 2);
 end;
 
+function TIcms201.ValorBaseIcmsST: Double;
+begin
+  Result := FBaseIcmsST.CalcularBaseIcmsST;
+end;
+
 function TIcms201.ValorIcmsST: Double;
 begin
   Result := RoundABNT(FIcmsST.CalcularValorIcmsST, 2);
+end;
+
+function TIcms201.ValorCreditoSN: Double;
+begin
+  Result := RoundABNT(ValorBaseIcmsProprio * (FPercentualCreditoSN / 100), 2);
 end;
 
 end.

--- a/src/Delphiscal.Icms202_203.pas
+++ b/src/Delphiscal.Icms202_203.pas
@@ -17,10 +17,10 @@ type
     function ValorBaseIcmsST: Double;
     function ValorIcmsST: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-      APercentualReducao, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
       APercentualReducao, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0): IIcms202_203;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+      APercentualReducao, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0);
     destructor Destroy; override;
   end;
 
@@ -28,11 +28,18 @@ implementation
 
 uses Delphiscal.Utils;
 
+class function TIcms202_203.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
+  AAliquotaIcms, APercentualReducao, AAliquotaIcmsST, AMva, APercentualReducaoST: Double): IIcms202_203;
+begin
+  Result := TIcms202_203.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+                                APercentualReducao, AAliquotaIcmsST, AMva, APercentualReducaoST);
+end;
+
 constructor TIcms202_203.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
   AAliquotaIcms, APercentualReducao, AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0);
 begin
   FBaseIcmsProprio := TBaseIcmsProprio.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-    APercentualReducao);
+                                              APercentualReducao);
   FIcmsProprio := TValorIcms.Create(FBaseIcmsProprio, AAliquotaIcms);
   FBaseIcmsST := TBaseIcmsST.Create(FBaseIcmsProprio, AMva, APercentualReducaoST);
   FIcmsST := TValorIcmsST.Create(FBaseIcmsST, AAliquotaIcmsST, FIcmsProprio);
@@ -47,26 +54,19 @@ begin
   inherited;
 end;
 
-class function TIcms202_203.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-  AAliquotaIcms, APercentualReducao, AAliquotaIcmsST, AMva, APercentualReducaoST: Double): IIcms202_203;
-begin
-  Result := TIcms202_203.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-    APercentualReducao, AAliquotaIcmsST, AMva, APercentualReducaoST);
-end;
-
 function TIcms202_203.ValorBaseIcmsProprio: Double;
 begin
   Result := FBaseIcmsProprio.CalcularBaseIcmsProprio;
 end;
 
-function TIcms202_203.ValorBaseIcmsST: Double;
-begin
-  Result := FBaseIcmsST.CalcularBaseIcmsST;
-end;
-
 function TIcms202_203.ValorIcmsProprio: Double;
 begin
   Result := RoundABNT(FIcmsProprio.GetValorIcms, 2);
+end;
+
+function TIcms202_203.ValorBaseIcmsST: Double;
+begin
+  Result := FBaseIcmsST.CalcularBaseIcmsST;
 end;
 
 function TIcms202_203.ValorIcmsST: Double;

--- a/src/Delphiscal.Icms30.pas
+++ b/src/Delphiscal.Icms30.pas
@@ -17,16 +17,23 @@ type
     function ValorIcmsST: Double;
     function ValorIcmsDesonerado: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-      AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
       AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0): IIcms30;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+      AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0);
     destructor Destroy; override;
   end;
 
 implementation
 
 uses Delphiscal.Utils;
+
+class function TIcms30.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+  AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi: Double): IIcms30;
+begin
+  Result := TIcms30.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
+                           AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi);
+end;
 
 constructor TIcms30.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
   AAliquotaIcmsST, AMva: Double; const APercentualReducaoST: Double = 0; const AValorIpi: Double = 0);
@@ -44,13 +51,6 @@ begin
   FBaseIcmsST.Free;
   FIcmsST.Free;
   inherited;
-end;
-
-class function TIcms30.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-  AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi: Double): IIcms30;
-begin
-  Result := TIcms30.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaIcms,
-    AAliquotaIcmsST, AMva, APercentualReducaoST, AValorIpi);
 end;
 
 function TIcms30.ValorBaseIcmsProprio: Double;

--- a/src/Delphiscal.Icms51.pas
+++ b/src/Delphiscal.Icms51.pas
@@ -15,10 +15,10 @@ type
     function ValorIcmsDiferido: Double;
     function ValorIcmsProprio: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
-      APercentualDiferimento: Double; const APercentualReducao: Double = 0; const AValorIpi: Double = 0);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
       APercentualDiferimento: Double; const APercentualReducao: Double = 0; const AValorIpi: Double = 0): IIcms51;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
+      APercentualDiferimento: Double; const APercentualReducao: Double = 0; const AValorIpi: Double = 0);
     destructor Destroy; override;
   end;
 
@@ -26,16 +26,18 @@ implementation
 
 uses Delphiscal.Utils;
 
-function TIcms51.BaseIcmsProprio: Double;
+class function TIcms51.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
+  APercentualDiferimento, APercentualReducao, AValorIpi: Double): IIcms51;
 begin
-  Result := FBaseIcmsProprio.CalcularBaseIcmsProprio;
+  Result := TIcms51.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
+                           APercentualDiferimento, APercentualReducao, AValorIpi);
 end;
 
 constructor TIcms51.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
   APercentualDiferimento: Double; const APercentualReducao: Double = 0; const AValorIpi: Double = 0);
 begin
   FBaseIcmsProprio := TBaseIcmsProprio.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-    APercentualReducao, AValorIpi);
+                                              APercentualReducao, AValorIpi);
   FValorIcmsOperacao := TValorIcms.Create(FBaseIcmsProprio, AALiquotaICMS);
   FPercentualDiferimento := APercentualDiferimento;
 end;
@@ -47,21 +49,19 @@ begin
   inherited;
 end;
 
-class function TIcms51.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
-  APercentualDiferimento, APercentualReducao, AValorIpi: Double): IIcms51;
+function TIcms51.BaseIcmsProprio: Double;
 begin
-  Result := TIcms51.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AALiquotaICMS,
-    APercentualDiferimento, APercentualReducao, AValorIpi);
-end;
-
-function TIcms51.ValorIcmsDiferido: Double;
-begin
-  Result := RoundABNT(FValorIcmsOperacao.GetValorIcms * (FPercentualDiferimento / 100), 2);
+  Result := FBaseIcmsProprio.CalcularBaseIcmsProprio;
 end;
 
 function TIcms51.ValorIcmsOperacao: Double;
 begin
   Result := RoundABNT(FValorIcmsOperacao.GetValorIcms, 2);
+end;
+
+function TIcms51.ValorIcmsDiferido: Double;
+begin
+  Result := RoundABNT(FValorIcmsOperacao.GetValorIcms * (FPercentualDiferimento / 100), 2);
 end;
 
 function TIcms51.ValorIcmsProprio: Double;

--- a/src/Delphiscal.Ipi50AdValorem.pas
+++ b/src/Delphiscal.Ipi50AdValorem.pas
@@ -12,8 +12,8 @@ type
     function BaseIpi: Double;
     function ValorIpi: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi: Double);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi: Double): IIpi50AdValorem;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi: Double);
     destructor Destroy; override;
   end;
 
@@ -21,15 +21,15 @@ implementation
 
 uses Delphiscal.Utils;
 
+class function TIpi50AdValorem.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi: Double): IIpi50AdValorem;
+begin
+  Result := TIpi50AdValorem.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi);
+end;
+
 constructor TIpi50AdValorem.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi: Double);
 begin
   FBaseIpi := TBaseIpi.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias);
   FAliquotaIpi := AAliquotaIpi;
-end;
-
-function TIpi50AdValorem.BaseIpi: Double;
-begin
-  Result := FBaseIpi.CalcularBaseIpi;
 end;
 
 destructor TIpi50AdValorem.Destroy;
@@ -38,9 +38,9 @@ begin
   inherited;
 end;
 
-class function TIpi50AdValorem.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi: Double): IIpi50AdValorem;
+function TIpi50AdValorem.BaseIpi: Double;
 begin
-  Result := TIpi50AdValorem.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AAliquotaIpi);
+  Result := FBaseIpi.CalcularBaseIpi;
 end;
 
 function TIpi50AdValorem.ValorIpi: Double;

--- a/src/Delphiscal.Ipi50Especifico.pas
+++ b/src/Delphiscal.Ipi50Especifico.pas
@@ -13,19 +13,18 @@ type
     function QuantidadeTributada(const AValue: Double): IIpi50Especifico;
     function ValorPorUnidadeTributada(const AValue: Double): IIpi50Especifico;
   public
-    constructor Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double); overload;
-    class function New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): IIpi50Especifico; overload;
     class function New: IIpi50Especifico; overload;
+    class function New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): IIpi50Especifico; overload;
+    constructor Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double); overload;
   end;
 
 implementation
 
 uses Delphiscal.Utils;
 
-constructor TIpi50Especifico.Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double);
+class function TIpi50Especifico.New: IIpi50Especifico;
 begin
-  FQuantidadeTributada := AQuantidadeTributada;
-  FValorUnidadeTributada := AValorPorUnidadeTributada;
+  Result := TIpi50Especifico.Create;
 end;
 
 class function TIpi50Especifico.New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): IIpi50Especifico;
@@ -33,9 +32,10 @@ begin
   Result := TIpi50Especifico.Create(AQuantidadeTributada, AValorPorUnidadeTributada);
 end;
 
-class function TIpi50Especifico.New: IIpi50Especifico;
+constructor TIpi50Especifico.Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double);
 begin
-  Result := TIpi50Especifico.Create;
+  FQuantidadeTributada := AQuantidadeTributada;
+  FValorUnidadeTributada := AValorPorUnidadeTributada;
 end;
 
 function TIpi50Especifico.ValorIpi: Double;

--- a/src/Delphiscal.Pis01_02.pas
+++ b/src/Delphiscal.Pis01_02.pas
@@ -12,8 +12,8 @@ type
     function BasePis: Double;
     function ValorPis: Double;
   public
-    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaPis: Double);
     class function New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaPis: Double): IPis01_02;
+    constructor Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaPis: Double);
     destructor Destroy; override;
   end;
 
@@ -21,9 +21,10 @@ implementation
 
 uses Delphiscal.Utils;
 
-function TPis01_02.BasePis: Double;
+class function TPis01_02.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
+  AAliquotaPis: Double): IPis01_02;
 begin
-  Result := FBasePis.CalcularBasePis;
+  Result := TPis01_02.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaPis);
 end;
 
 constructor TPis01_02.Create(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
@@ -39,10 +40,9 @@ begin
   inherited;
 end;
 
-class function TPis01_02.New(const AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto,
-  AAliquotaPis: Double): IPis01_02;
+function TPis01_02.BasePis: Double;
 begin
-  Result := TPis01_02.Create(AValorProduto, AValorFrete, AValorSeguro, ADespesasAcessorias, AValorDesconto, AAliquotaPis);
+  Result := FBasePis.CalcularBasePis;
 end;
 
 function TPis01_02.ValorPis: Double;

--- a/src/Delphiscal.Pis03.pas
+++ b/src/Delphiscal.Pis03.pas
@@ -13,19 +13,18 @@ type
     function QuantidadeTributada(const AValue: Double): IPis03;
     function ValorPorUnidadeTributada(const AValue: Double): IPis03;
   public
-    constructor Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double); overload;
-    class function New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): IPis03; overload;
     class function New: IPis03; overload;
+    class function New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): IPis03; overload;
+    constructor Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double); overload;
   end;
 
 implementation
 
 uses Delphiscal.Utils;
 
-constructor TPis03.Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double);
+class function TPis03.New: IPis03;
 begin
-  FQuantidadeTributada := AQuantidadeTributada;
-  FValorUnidadeTributada := AValorPorUnidadeTributada;
+  Result := TPis03.Create;
 end;
 
 class function TPis03.New(const AQuantidadeTributada, AValorPorUnidadeTributada: Double): IPis03;
@@ -33,9 +32,10 @@ begin
   Result := TPis03.Create(AQuantidadeTributada, AValorPorUnidadeTributada);
 end;
 
-class function TPis03.New: IPis03;
+constructor TPis03.Create(const AQuantidadeTributada, AValorPorUnidadeTributada: Double);
 begin
-  Result := TPis03.Create;
+  FQuantidadeTributada := AQuantidadeTributada;
+  FValorUnidadeTributada := AValorPorUnidadeTributada;
 end;
 
 function TPis03.ValorPis: Double;


### PR DESCRIPTION
*Adicionado o IPI no calculo da base do ICMS ST do ICMS 70; 
*Colocado para utilizar função para validar se há redução na base ST para reduzir código duplicado; 
*Reorganizado posição dos métodos para tornar a leitura das units mais fluida;